### PR TITLE
fix: terraform version error

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -31,16 +31,15 @@ jobs:
 
       - name: Install Terraform
         run: |
-          curl -sL https://releases.hashicorp.com/terraform/1.12.2/terraform_1.12.2_linux_amd64.zip -o terraform.zip
-          unzip -q terraform.zip
-          sudo mv terraform /usr/local/bin/
-          rm terraform.zip
-          terraform -v
+          sudo bash ./scripts/install-terraform.sh
       
       - name: Run Terraform for selected account
         run: |
           DECODED_JSON=$(echo '${{ secrets.OCI_ACCOUNTS_JSON }}' | base64 -d)
-                    
+          TEMP_JSON_PATH="${{ runner.temp }}/accounts.json"
+
+          echo "Creating temporary config file at: $TEMP_JSON_PATH"
+
           echo "🔍 Validating JSON structure:"
           if echo "$DECODED_JSON" | jq empty 2>/dev/null; then
               echo "✅ JSON is valid"
@@ -50,16 +49,17 @@ jobs:
               exit 1
           fi
 
-          echo "$DECODED_JSON" > /tmp/teste.json
+          echo "$DECODED_JSON" > "$TEMP_JSON_PATH"
       
-          bash ./scripts/deploy.sh /tmp/teste.json ${{ github.event.inputs.account_number }} ${{ github.event.inputs.operation }} $(pwd)/accounts
+          bash ./scripts/deploy.sh "$TEMP_JSON_PATH" ${{ github.event.inputs.account_number }} ${{ github.event.inputs.operation }} $(pwd)/accounts
       
-          rm -rf /tmp/teste.json
+          rm -rf "$TEMP_JSON_PATH"
 
-      - name: Clean up sensitive files
+      - name: Clean up Terraform sensitive files
         if: always()
         working-directory: ./accounts
         run: |
+          echo "🧹 Final cleanup of sensitive files from the workspace..."
           rm -f private_key.pem
           rm -rf .terraform
           rm -rf .terraform.lock.hcl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # 📦 CHANGELOG
 
+## v1.0.1 — Fix Terraform install version in CI/CD 🔧
+
+### Fixed
+- Enforced Terraform v1.13.0 in `install-terraform.sh`
+- Updated GitHub Actions workflow to use the script correctly
+- Added workflow badge to `README.md`
+
+---
+
 ## v1.0.0 — Modular & Multi-Account OCI Infrastructure 🚀
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Terraform OCI IaC Workflow](https://github.com/glauciolabs/oci-iac-ops/actions/workflows/terraform.yml/badge.svg)](https://github.com/glauciolabs/oci-iac-ops/actions/workflows/terraform.yml)
+
+
 # Terraform OCI Multi-Account Infrastructure
 
 This guide will help you understand and use the Terraform solution for deploying Oracle Cloud Infrastructure (OCI) resources across multiple accounts. It’s detailed and beginner-friendly to help users new to Terraform, OCI, or infrastructure automation.

--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,5 @@
 # Current Version
 
-**v1.0.0** — Modular & Multi-Account OCI Infrastructure
+**v1.0.1** — Fix Terraform install version in CI/CD
 
-Released on: 2025-08-23
+Released on: 2025-08-24


### PR DESCRIPTION
This PR fixes a version mismatch in the Terraform install script used by the CI/CD workflow.

🔧 Changes
Updated scripts/install-terraform.sh to install Terraform v1.13.0

Adjusted GitHub Actions workflow to call the script via sudo bash

Added workflow badge to README.md for visibility

🧪 Validation
CI now installs the correct version

Badge reflects workflow status

Local runs match expected Terraform version